### PR TITLE
While selecting three themes "Windows, Hacker and Android" we will get a validation error saying : "Please match the requested format."

### DIFF
--- a/src/const/themes.ts
+++ b/src/const/themes.ts
@@ -1,5 +1,6 @@
 import { type Theme } from "@/types";
 
+
 /**
  * This `Map` stores all the themes that are currently available.
  * In order to add a new theme, use the `set` method.
@@ -140,21 +141,21 @@ themes.set("blood_dark", {
 });
 themes.set("hacker", {
   backgroundColor: "#101010",
-  borderColor: "#222",
+  borderColor: "#222222", // this one is creating a bug if we write #222 instead of #222222. 
   titleColor: "#1DDB07",
-  badgeColor: "#222",
+  badgeColor: "#222222",  // this one is creating a bug if we write #222 instead of #222222. 
 });
 themes.set("android", {
   backgroundColor: "#101010",
-  borderColor: "#222",
+  borderColor: "#222222", // this one is creating a bug if we write #222 instead of #222222.
   titleColor: "#3ADD85",
-  badgeColor: "#222",
+  badgeColor: "#222222", // this one is creating a bug if we write #222 instead of #222222.
 });
 themes.set("windows", {
   backgroundColor: "#101010",
-  borderColor: "#222",
+  borderColor: "#222222", // this one is creating a bug if we write #222 instead of #222222.
   titleColor: "#00A3EE",
-  badgeColor: "#222",
+  badgeColor: "#222222", // this one is creating a bug if we write #222 instead of #222222.
 });
 themes.set("halloween", {
   backgroundColor: "#1C1A2B",


### PR DESCRIPTION
While selecting three themes "Windows, Hacker and Android" we will get a validation error saying : "Please match the requested format."

Steps to reproduce the behavior:

   1. Go to ['https://github-readme-tech-stack.vercel.app/'](https://github-readme-tech-stack.vercel.app/)
   2. Click on 'Next'
   3. Choose the "Windows/Hacker/Android" theme and then Click "Load Colors"
   4. Now when you try to click next, it will say error "Please match the requested format."

Expected behavior
While using other themes it will not give this error.

ScreenShot
![please-match-the-requested-format-error](https://github.com/user-attachments/assets/03cf6a0f-01fd-48ed-a762-ead419273431)

Additional context
I have solved this problem in this PR by completing the three character/numeric value to six character/numeric value in faulty themes.
